### PR TITLE
Backport fix for GPU on WSL

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ogre-next-2.3 (2.3.1-4) jammy; urgency=medium
+
+  * Backport upstream PR 388 to fix GPU acceleration on WSL
+
+ -- Silvio Traversaro <silvio@traversaro.it>  Tue, 01 Aug 2023 09:30:48 +0200
+
 ogre-next-2.3 (2.3.1-3) jammy; urgency=medium
 
   * Fix vulkan dep 

--- a/debian/patches/fix-gpu-in-wsl.patch
+++ b/debian/patches/fix-gpu-in-wsl.patch
@@ -1,3 +1,6 @@
+Description: Fix GPU on Windows Subsystem for Linux
+Origin: https://github.com/OGRECave/ogre-next/pull/388
+
 diff --git a/RenderSystems/GL3Plus/src/OgreGL3PlusTextureGpu.cpp b/RenderSystems/GL3Plus/src/OgreGL3PlusTextureGpu.cpp
 index c9a1147b188..85a94ae7a71 100644
 --- a/RenderSystems/GL3Plus/src/OgreGL3PlusTextureGpu.cpp

--- a/debian/patches/fix-gpu-in-wsl.patch
+++ b/debian/patches/fix-gpu-in-wsl.patch
@@ -1,0 +1,36 @@
+diff --git a/RenderSystems/GL3Plus/src/OgreGL3PlusTextureGpu.cpp b/RenderSystems/GL3Plus/src/OgreGL3PlusTextureGpu.cpp
+index c9a1147b188..85a94ae7a71 100644
+--- a/RenderSystems/GL3Plus/src/OgreGL3PlusTextureGpu.cpp
++++ b/RenderSystems/GL3Plus/src/OgreGL3PlusTextureGpu.cpp
+@@ -649,15 +649,23 @@ namespace Ogre
+                                           dstBox.getZOrSlice() + dstGl->getInternalSliceStart(),
+                                           srcBox.width, srcBox.height, srcBox.getDepthOrSlices() ) );
+             }
+-            /*TODO
+             else if( support.checkExtension( "GL_NV_copy_image" ) )
+-            {
+-                OCGE( glCopyImageSubDataNV( this->mFinalTextureName, this->mGlTextureTarget,
+-                                            srcMipLevel, srcBox.x, srcBox.y, srcBox.z,
+-                                            dstGl->mFinalTextureName, dstGl->mGlTextureTarget,
+-                                            dstMipLevel, dstBox.x, dstBox.y, dstBox.z,
+-                                            srcBox.width, srcBox.height, srcBox.getDepthOrSlices() ) );
+-            }*/
++            {
++                 // Initialize the pointer only the first time
++                PFNGLCOPYIMAGESUBDATANVPROC local_glCopyImageSubDataNV = nullptr;
++                if (!local_glCopyImageSubDataNV)
++                {
++                    local_glCopyImageSubDataNV = (PFNGLCOPYIMAGESUBDATANVPROC)gl3wGetProcAddress("glCopyImageSubDataNV");
++                }
++
++                OCGE( local_glCopyImageSubDataNV( this->mFinalTextureName, this->mGlTextureTarget,
++                                                  srcMipLevel, srcBox.x, srcBox.y,
++                                                  srcBox.getZOrSlice() + this->getInternalSliceStart(),
++                                                  dstGl->mFinalTextureName, dstGl->mGlTextureTarget,
++                                                  dstMipLevel, dstBox.x, dstBox.y,
++                                                  dstBox.getZOrSlice() + dstGl->getInternalSliceStart(),
++                                                  srcBox.width, srcBox.height, srcBox.getDepthOrSlices() ) );
++            }
+             /*TODO: These are for OpenGL ES 3.0+
+             else if( support.checkExtension( "GL_OES_copy_image" ) )
+             {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -6,3 +6,4 @@ vulkan-look-for-validationlayers.patch
 versioned-header-dir.patch
 versioned-pc-files.patch
 install-pc-files-to-lib-multiarch.patch
+fix-gpu-in-wsl.patch


### PR DESCRIPTION
This PR backports the upstream fix https://github.com/OGRECave/ogre-next/pull/388 to the ogre-next debian packages. I am not an expert of Debian packaging, so I could have done something wrong. 

The change itself should only affect system that before this change were crashing with error "Ogre::UnimplementedException", and not do anything on system that are not crashing, so it should be relatively safe to merge.

cc @j-rivero @azeey @bperseghetti 
